### PR TITLE
fix: use valid sender fields in transaction examples

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -33,7 +33,7 @@ const result = await supply(client, {
       value: '1000'
     }
   },
-  supplier: evmAddress('0x742d35cc6e5c4ce3b69a2a8c7c8e5f7e9a0b1234'),
+  sender: evmAddress('0x742d35cc6e5c4ce3b69a2a8c7c8e5f7e9a0b1234'),
   chainId: chainId(1),
 })
   .andThen(sendWith(wallet))

--- a/packages/client/src/actions/misc.ts
+++ b/packages/client/src/actions/misc.ts
@@ -134,7 +134,7 @@ export function hasProcessedKnownTransaction(
  *           value: '1000',
  *         },
  *       },
- *       borrower: evmAddress('0x9abc…'),
+ *       sender: evmAddress('0x9abc…'),
  *       chainId: market.chain.chainId,
  *     },
  *   },

--- a/packages/client/src/actions/transactions.ts
+++ b/packages/client/src/actions/transactions.ts
@@ -51,7 +51,7 @@ import type { AaveClient } from '../AaveClient';
  *       value: '1000',
  *     },
  *   },
- *   borrower: evmAddress('0x9abc…'),
+ *   sender: evmAddress('0x9abc…'),
  *   chainId: market.chain.chainId,
  * }).andThen(sendWith(wallet)).andThen(client.waitForTransaction);
  *
@@ -86,7 +86,7 @@ export function borrow(
  *       value: '1000',
  *     },
  *   },
- *   supplier: evmAddress('0x9abc…'),
+ *   sender: evmAddress('0x9abc…'),
  *   chainId: market.chain.chainId,
  * }).andThen(sendWith(wallet)).andThen(client.waitForTransaction);
  *
@@ -123,7 +123,7 @@ export function supply(
  *       },
  *     },
  *   },
- *   borrower: evmAddress('0x9abc…'),
+ *   sender: evmAddress('0x9abc…'),
  *   chainId: market.chain.chainId,
  * }).andThen(sendWith(wallet)).andThen(client.waitForTransaction);
  *
@@ -158,7 +158,7 @@ export function repay(
  *       value: { exact: '750' },
  *     },
  *   },
- *   supplier: evmAddress('0x9abc…'),
+ *   sender: evmAddress('0x9abc…'),
  *   chainId: market.chain.chainId,
  * }).andThen(sendWith(wallet)).andThen(client.waitForTransaction);
  *

--- a/packages/react/src/ethers.ts
+++ b/packages/react/src/ethers.ts
@@ -76,7 +76,7 @@ export type SendTransactionError =
  *         value: '42.42',
  *       }
  *     },
- *     supplier: evmAddress(await signer.getAddress()),
+ *     sender: evmAddress(await signer.getAddress()),
  *   })
  *     .andThen((plan) => {
  *       switch (plan.__typename) {

--- a/packages/react/src/misc.ts
+++ b/packages/react/src/misc.ts
@@ -169,7 +169,7 @@ export function useUsdExchangeRates({
  *           value: '1000',
  *         },
  *       },
- *       borrower: evmAddress('0x9abc…'),
+ *       sender: evmAddress('0x9abc…'),
  *       chainId: market.chain.chainId,
  *     },
  *   },

--- a/packages/react/src/privy.ts
+++ b/packages/react/src/privy.ts
@@ -78,7 +78,7 @@ export type SendTransactionError =
  *         value: '42.42',
  *       }
  *     },
- *     supplier: evmAddress(account.address!),
+ *     sender: evmAddress(account.address!),
  *   })
  *     .andThen((plan) => {
  *       switch (plan.__typename) {

--- a/packages/react/src/thirdweb.ts
+++ b/packages/react/src/thirdweb.ts
@@ -89,7 +89,7 @@ export type SendTransactionError =
  *         value: '42.42',
  *       }
  *     },
- *     supplier: evmAddress(account!.address),
+ *     sender: evmAddress(account!.address),
  *   })
  *     .andThen((plan) => {
  *       switch (plan.__typename) {

--- a/packages/react/src/viem.ts
+++ b/packages/react/src/viem.ts
@@ -75,7 +75,7 @@ export type SendTransactionError =
  *         value: '42.42',
  *       }
  *     },
- *     supplier: evmAddress(account.address!),
+ *     sender: evmAddress(account.address!),
  *   })
  *     .andThen((plan) => {
  *       switch (plan.__typename) {


### PR DESCRIPTION
## Summary
- Replace stale `supplier`/`borrower` fields with `sender` in transaction examples
- Cover client README, transaction action JSDoc, health-factor preview examples, and React send helpers

## Why
The public examples currently do not match the exported request types in the schema. `BorrowRequest`, `SupplyRequest`, `RepayRequest`, and `WithdrawRequest` all use `sender`, so users copying the snippets run into TypeScript errors.

Closes #149.

## Validation
- `pnpm lint`
- `pnpm build`