### PR TITLE
feat: adds react hook useSavingsGhoIncentive & simplified request

### DIFF
--- a/packages/graphql/src/incentives.ts
+++ b/packages/graphql/src/incentives.ts
@@ -56,6 +56,3 @@ export const SavingsGhoIncentiveQuery = graphql(
   }`,
   [MeritSavingsGhoIncentiveFragment],
 );
-export type SavingsGhoIncentiveRequest = RequestOf<
-  typeof SavingsGhoIncentiveQuery
->;

--- a/packages/react/src/gho.ts
+++ b/packages/react/src/gho.ts
@@ -1,13 +1,17 @@
-import type { UnexpectedError } from '@aave/client';
+import type { ChainId, UnexpectedError } from '@aave/client';
 import { savingsGhoDeposit, savingsGhoWithdraw } from '@aave/client/actions';
 import type {
   ExecutionPlan,
+  MeritSavingsGhoIncentive,
   SavingsGhoBalanceRequest,
   SavingsGhoDepositRequest,
   SavingsGhoWithdrawRequest,
   TokenAmount,
 } from '@aave/graphql';
-import { SavingsGhoBalanceQuery } from '@aave/graphql';
+import {
+  SavingsGhoBalanceQuery,
+  SavingsGhoIncentiveQuery,
+} from '@aave/graphql';
 import { useAaveClient } from './context';
 import type {
   ReadResult,
@@ -22,6 +26,9 @@ import {
 } from './helpers';
 
 export type SavingsGhoBalanceArgs = SavingsGhoBalanceRequest;
+export type SavingsGhoIncentiveArgs = {
+  chainId?: ChainId;
+};
 
 /**
  * Fetches the current sGHO balance for a user.
@@ -62,6 +69,50 @@ export function useSavingsGhoBalance({
     document: SavingsGhoBalanceQuery,
     variables: {
       request,
+    },
+    suspense,
+  });
+}
+
+/**
+ * Fetches the active Merit APR incentive for sGHO.
+ *
+ * This signature supports React Suspense:
+ *
+ * ```tsx
+ * const { data } = useSavingsGhoIncentive({
+ *   chainId: chainId(1),
+ *   suspense: true,
+ * });
+ * ```
+ */
+export function useSavingsGhoIncentive(
+  args: SavingsGhoIncentiveArgs & Suspendable,
+): SuspenseResult<MeritSavingsGhoIncentive | null>;
+
+/**
+ * Fetches the active Merit APR incentive for sGHO.
+ *
+ * ```tsx
+ * const { data, error, loading } = useSavingsGhoIncentive({
+ *   chainId: chainId(1),
+ * });
+ * ```
+ */
+export function useSavingsGhoIncentive(
+  args?: SavingsGhoIncentiveArgs,
+): ReadResult<MeritSavingsGhoIncentive | null>;
+
+export function useSavingsGhoIncentive({
+  suspense = false,
+  chainId,
+}: SavingsGhoIncentiveArgs & {
+  suspense?: boolean;
+} = {}): SuspendableResult<MeritSavingsGhoIncentive | null> {
+  return useSuspendableQuery({
+    document: SavingsGhoIncentiveQuery,
+    variables: {
+      chainId,
     },
     suspense,
   });


### PR DESCRIPTION
* Adds a new `useSavingsGhoIncentive` React hook for fetching the active sGHO Merit APR incentive through the SDK.

* The hook follows the existing read-query pattern used across `@aave/react`, supports Suspense, and accepts an optional `chainId` argument.

* Also removes the unused `SavingsGhoIncentiveRequest` type because this query does not use the standard `$request` variable shape. It only requires `chainId`, so the React hook defines its args explicitly.
