### PR TITLE
chore: bumps up versions

### DIFF
--- a/.changeset/privy-peer-dep.md
+++ b/.changeset/privy-peer-dep.md
@@ -1,5 +1,0 @@
----
-"@aave/client": minor
----
-
-Move `@privy-io/server-auth` from dependencies to peerDependencies

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aave/client
 
+## 0.11.0
+
+### Minor Changes
+
+- 4a60cfa: Move `@privy-io/server-auth` from dependencies to peerDependencies
+
 ## 0.10.0
 
 ### Minor Changes

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/client",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "The official JavaScript client for the Aave API",
   "repository": {
     "directory": "packages/client",

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aave/react
 
+## 0.9.1
+
+### Patch Changes
+
+- Updated dependencies [4a60cfa]
+  - @aave/client@0.11.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aave/react",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "The official React bindings for the Aave Protocol",
   "repository": {
     "directory": "packages/react",


### PR DESCRIPTION
## Summary

- Bumps `@aave/client` from `0.10.0` → `0.11.0` (minor)
- Bumps `@aave/react` from `0.9.0` → `0.9.1` (patch)

Packages have already been published to npm. This PR merges the version bump commit so main stays in sync with the published versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)